### PR TITLE
fix: 修复 Star History 图表

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -284,4 +284,4 @@ limitations under the License.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huey1in/kirox&type=Date)](https://star-history.com/#huey1in/kirox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huey1in/kirox&type=Date)](https://star-history.dera.page/#huey1in/kirox&Date)

--- a/README.ja.md
+++ b/README.ja.md
@@ -284,4 +284,4 @@ limitations under the License.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huey1in/kirox&type=Date)](https://star-history.com/#huey1in/kirox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huey1in/kirox&type=Date)](https://star-history.dera.page/#huey1in/kirox&Date)

--- a/README.md
+++ b/README.md
@@ -289,4 +289,4 @@ limitations under the License.
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=huey1in/kirox&type=Date)](https://star-history.com/#huey1in/kirox&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=huey1in/kirox&type=Date)](https://star-history.dera.page/#huey1in/kirox&Date)


### PR DESCRIPTION
Star History 图表目前因 GitHub API 限制而失效，已切换到替代数据源以确保图表继续正常显示。更新了所有语言的 README 图表链接。